### PR TITLE
Features/simple rasterizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ var pdf = scissors('in.pdf')
    .compress()
    .uncompress()
    .crop(100, 100, 300, 200) // offset in points from left, bottom, right, top
+   .encrypt({
+        userPass: 'foo',
+        ownerPadd: 'bar',
+        allow: ['printing','degradedprinting']
+   })
 
 // Join multiple files...
 var pdfA = scissors('1.pdf'), pdfB = scissors('2.pdf'), pdfC = scissors('3.pdf')

--- a/bin/rasterize.js
+++ b/bin/rasterize.js
@@ -37,14 +37,22 @@ function readBoundingBox (ins, page, next) {
 	});
 }
 
-function rasterizeImage (ins, page, dpi, boundingbox) {
+function rasterizeImage (ins, page, dpi, format, boundingbox) {
 	var multiplier = dpi / 72;
+	var device;
+	if (format == 'png') {
+		device = 'png16m';
+	}
+	else {
+		device = 'jpeg';
+	}
+
 	var gs = spawn('gs', [
 		'-q',
-		'-sDEVICE=png16m',
+		'-sDEVICE=' + device,
 	  '-sOutputFile=-',
 	  '-r' + dpi,
-	  '-g' + 
+	  '-g' +
 	  	Math.ceil((boundingbox[2] - boundingbox[0] + 2)*multiplier) +
 	  	'x' + Math.ceil((boundingbox[3] - boundingbox[1] + 2)*multiplier),
 	  '-dNOPAUSE', '-dBATCH',
@@ -93,7 +101,7 @@ createTempFile(function (path) {
 		if (err) {
 			return debug(err);
 		}
-		rasterizeImage(fs.createReadStream(path), page, dpi, boundingbox)
+		rasterizeImage(fs.createReadStream(path), page, dpi, format, boundingbox)
 			.pipe(process.stdout);
 	});
 	inputStream.resume();

--- a/bin/simple_rasterize.js
+++ b/bin/simple_rasterize.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var spawn = require('child_process').spawn;
+
+require('bufferjs/indexOf');
+
+function debug () {
+	console.error.apply(console, arguments);
+}
+
+function rasterizeImage (ins, page, dpi, format, useCropBox) {
+	var device;
+	if (format == 'png') {
+		device = 'png16m';
+	}
+	else {
+		device = 'jpeg';
+	}
+
+  var gsArgs = [
+		'-q',
+		'-sDEVICE=' + device,
+		'-sOutputFile=-',
+		'-r' + dpi,
+		'-dNOPAUSE',
+		'-dBATCH',
+		'-dFirstPage=' + page,
+		'-dLastPage=' + page,
+		'-f',
+		'-'
+	];
+
+	if (useCropBox) {
+		gsArgs.unshift('-dUseCropBox');
+	}
+	
+	var gs = spawn('gs', gsArgs);
+
+	ins.pipe(gs.stdin);
+
+	gs.stderr.on('data', function (data) {
+		debug('gs encountered an error:\n', String(data));
+	});
+
+	gs.on('exit', function (code) {
+		if (code) {
+			debug('gs exited with failure code:', code);
+		}
+		debug('Finished writing image.');
+	});
+
+	return gs.stdout;
+}
+
+if (process.argv.length < 5) {
+	debug('Invalid number of arguments.');
+	process.exit(1);
+}
+
+var input = process.argv[2];
+var format = process.argv[3];
+var page = Number(process.argv[4]) || 1;
+var dpi = Number(process.argv[5]) || 72;
+var useCropBox = process.argv[6] == 'true';
+
+var inputStream = input == '-' ? process.stdin : fs.createReadStream(input);
+rasterizeImage(inputStream, page, dpi, format, useCropBox).pipe(process.stdout);

--- a/scissors.js
+++ b/scissors.js
@@ -7,6 +7,8 @@ var BufferStream = require('bufferstream');
 var temp = require('temp').track();
 var async = require('async');
 
+var PDFTKCMD = 'pdftk';
+
 // Calls functions once a promise has been delivered.
 // Queue functions by using promise(yourCallback); Deliver the promise using promise.deliver().
 // Once the promise has been delivered, promise(yourCallback) immediately calls.
@@ -92,7 +94,7 @@ Command.prototype.encrypt = function(options) {
 Command.prototype.range = function (min, max) {
   var cmd = this._copy();
   return cmd._push([
-    'pdftk', cmd._input(),
+    PDFTKCMD, cmd._input(),
     'cat', min + (max === null ? '' : '-' + max),
     'output', '-'
     ]);
@@ -102,7 +104,7 @@ Command.prototype.pages = function () {
   var args = Array.prototype.slice.call(arguments);
   var cmd = this._copy();
   return cmd._push([
-    'pdftk', cmd._input(),
+    PDFTKCMD, cmd._input(),
     'cat'].concat(args.map(Number), [
       'output', '-'
       ]));
@@ -111,7 +113,7 @@ Command.prototype.pages = function () {
 Command.prototype.odd = function (min, max) {
   var cmd = this._copy();
   return cmd._push([
-    'pdftk', cmd._input(),
+    PDFTKCMD, cmd._input(),
     'cat', 'odd',
     'output', '-'
     ]);
@@ -120,7 +122,7 @@ Command.prototype.odd = function (min, max) {
 Command.prototype.even = function (min, max) {
   var cmd = this._copy();
   return cmd._push([
-    'pdftk', cmd._input(),
+    PDFTKCMD, cmd._input(),
     'cat', 'even',
     'output', '-'
     ]);
@@ -129,7 +131,7 @@ Command.prototype.even = function (min, max) {
 Command.prototype.reverse = function (min, max) {
   var cmd = this._copy();
   return cmd._push([
-    'pdftk', cmd._input(),
+    PDFTKCMD, cmd._input(),
     'cat', 'end-1',
     'output', '-'
     ]);
@@ -146,7 +148,7 @@ Command.prototype.rotate = function (amount) {
     default: return this;
   }
   return cmd._push([
-    'pdftk', cmd._input(),
+    PDFTKCMD, cmd._input(),
     'cat', '1-end' + dir,
     'output', '-'
     ]);
@@ -155,7 +157,7 @@ Command.prototype.rotate = function (amount) {
 Command.prototype.compress = function () {
   var cmd = this._copy();
   return cmd._push([
-    'pdftk', cmd._input(), 'output', '-',
+    PDFTKCMD, cmd._input(), 'output', '-',
     'compress'
     ]);
 };
@@ -163,7 +165,7 @@ Command.prototype.compress = function () {
 Command.prototype.uncompress = function () {
   var cmd = this._copy();
   return cmd._push([
-    'pdftk', cmd._input(), 'output', '-',
+    PDFTKCMD, cmd._input(), 'output', '-',
     'uncompress'
     ]);
 };
@@ -173,7 +175,7 @@ Command.prototype.repair = function () {
   // "repairing" using pdftk fixes this.
   var cmd = this._copy();
   var args = [
-    'pdftk', this._input(), 'output', '-',
+    PDFTKCMD, this._input(), 'output', '-',
     ];
   // Don't double-repair.
   if (JSON.stringify(this.commands[this.commands.length - 1]) != JSON.stringify(args)) {
@@ -419,7 +421,7 @@ scissors.join = function () {
         next(null, file);
       });
   }, function (err, files) {
-    command = ['pdftk'].concat(files, ['output', outfile]);
+    command = [PDFTKCMD].concat(files, ['output', outfile]);
     var prog = spawn(command[0], command.slice(1));
     prog.stderr.on('data', function (data) {
       process.stderr.write(command[0].match(/[^\/]*$/)[0] + ': ' + String(data));

--- a/scissors.js
+++ b/scissors.js
@@ -194,9 +194,18 @@ Command.prototype.pdfStream = function () {
   return cmd._exec();
 };
 
-Command.prototype.pngStream = function (dpi) {
+Command.prototype.pngStream = function (dpi, page, useSimpleRasterize, useCropBox) {
+  return this.imageStream(dpi, 'png', page, useSimpleRasterize, useCropBox);
+};
+
+Command.prototype.jpgStream = function (dpi, page, useSimpleRasterize, useCropBox) {
+  return this.imageStream(dpi, 'jpg', page, useSimpleRasterize, useCropBox);
+};
+
+Command.prototype.imageStream = function (dpi, format, page, useSimpleRasterize, useCropBox) {
   var cmd = this.repair();
-  cmd._push([path.join(__dirname, 'bin/rasterize.js'), this._input(), 'pdf', 1, dpi || 72]);
+  var rasterizer = useSimpleRasterize ? 'bin/simple_rasterize.js' : 'bin/rasterize.js';
+  cmd._push([path.join(__dirname, rasterizer), this._input(), format || 'png', page || 1, dpi || 72, useCropBox ? 'true' : 'false']);
   var stream = cmd._exec();
   return stream;
 };
@@ -276,7 +285,7 @@ Command.prototype.contentStream = function () {
         str += decode(cmd.string);
       } else {
         stream.emit('data', {
-          type: 'string', x: (first || cmd).x, y: (first || cmd).y, 
+          type: 'string', x: (first || cmd).x, y: (first || cmd).y,
           string: str, font: font, color: color
         });
         str = decode(cmd.string);
@@ -296,7 +305,7 @@ Command.prototype.contentStream = function () {
   }).on('end', function () {
     if (str) {
       stream.emit('data', {
-        type: 'string', x: (first || cmd).x, y: (first || cmd).y, 
+        type: 'string', x: (first || cmd).x, y: (first || cmd).y,
         string: str, font: font, color: color
       });
       str = '';

--- a/test/test.js
+++ b/test/test.js
@@ -39,4 +39,120 @@ describe('Scissors', function() {
       });
     });
   });
+
+  describe('#jpgStream()', function() {
+    it('should extract a single jpg page (using default rasterize)', function(done) {
+      var outfile = dir+'/_page1_default.jpg';
+      var dpi = 300;
+      var pageNum = 1;
+      var useSimpleRasterize = false;
+      try{ fs.unlinkSync(outfile); } catch(e){/**/}
+      scissors(pdf)
+      .jpgStream(dpi, pageNum, useSimpleRasterize).pipe(fs.createWriteStream(outfile))
+      .on('close', function(){
+        assert.equal(true,fs.existsSync(outfile));
+        done();
+      })
+      .on('error',function(err){
+        console.error(err.message);
+      });
+    });
+  });
+
+  describe('#pngStream()', function() {
+    it('should extract a single png page (using default rasterize)', function(done) {
+      var outfile = dir+'/_page1_default.png';
+      var dpi = 300;
+      var pageNum = 1;
+      var useSimpleRasterize = false;
+      try{ fs.unlinkSync(outfile); } catch(e){/**/}
+      scissors(pdf)
+      .pngStream(dpi, pageNum, useSimpleRasterize).pipe(fs.createWriteStream(outfile))
+      .on('close', function(){
+        assert.equal(true,fs.existsSync(outfile));
+        done();
+      })
+      .on('error',function(err){
+        console.error(err.message);
+      });
+    });
+  });
+
+  describe('#jpgStream()', function() {
+    it('should extract a single jpg page (using simple rasterize)', function(done) {
+      var outfile = dir+'/_page1_simple.jpg';
+      var dpi = 300;
+      var pageNum = 1;
+      var useSimpleRasterize = true;
+      try{ fs.unlinkSync(outfile); } catch(e){/**/}
+      scissors(pdf)
+      .jpgStream(dpi, pageNum, useSimpleRasterize).pipe(fs.createWriteStream(outfile))
+      .on('close', function(){
+        assert.equal(true,fs.existsSync(outfile));
+        done();
+      })
+      .on('error',function(err){
+        console.error(err.message);
+      });
+    });
+  });
+
+  describe('#pngStream()', function() {
+    it('should extract a single png page (using simple rasterize)', function(done) {
+      var outfile = dir+'/_page1_simple.png';
+      var dpi = 300;
+      var pageNum = 1;
+      var useSimpleRasterize = true;
+      try{ fs.unlinkSync(outfile); } catch(e){/**/}
+      scissors(pdf)
+      .pngStream(dpi, pageNum, useSimpleRasterize).pipe(fs.createWriteStream(outfile))
+      .on('close', function(){
+        assert.equal(true,fs.existsSync(outfile));
+        done();
+      })
+      .on('error',function(err){
+        console.error(err.message);
+      });
+    });
+  });
+
+  describe('#jpgStream()', function() {
+    it('should extract a single jpg page using crop box (using simple rasterize)', function(done) {
+      var outfile = dir+'/_page1_simple_crop_box.jpg';
+      var dpi = 300;
+      var pageNum = 1;
+      var useSimpleRasterize = true;
+      var useCropBox = true;
+      try{ fs.unlinkSync(outfile); } catch(e){/**/}
+      scissors(pdf)
+      .jpgStream(dpi, pageNum, useSimpleRasterize, useCropBox).pipe(fs.createWriteStream(outfile))
+      .on('close', function(){
+        assert.equal(true,fs.existsSync(outfile));
+        done();
+      })
+      .on('error',function(err){
+        console.error(err.message);
+      });
+    });
+  });
+
+  describe('#pngStream()', function() {
+    it('should extract a single png page using crop box (using simple rasterize)', function(done) {
+      var outfile = dir+'/_page1_simple_crop_box.png';
+      var dpi = 300;
+      var pageNum = 1;
+      var useSimpleRasterize = true;
+      var useCropBox = true;
+      try{ fs.unlinkSync(outfile); } catch(e){/**/}
+      scissors(pdf)
+      .pngStream(dpi, pageNum, useSimpleRasterize, useCropBox).pipe(fs.createWriteStream(outfile))
+      .on('close', function(){
+        assert.equal(true,fs.existsSync(outfile));
+        done();
+      })
+      .on('error',function(err){
+        console.error(err.message);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Add more generic imageStream function which allows you to
1) Pass in page number and format for output
2) Add option to use simple rasterizer that skips temp file creation and bounding box code.
3) Add option to use the crop box for generating images from PDF.  This results in the most accurate resulting image.

I opted to leave the original rasterizer method as is for backwards compatability. 

The original rasterizer has several limitations. It uses this funky bounding box code to crop the resulting image.  Not only is this super slow, but it is not a good representation of the original page from the PDF.  See samples below.

Added new mocha tests:
```
mocha -t 7000

  Scissors
    #range()
      1) should extract a range of pdf pages (using a stream)
    #range()
      2) should extract a range of pdf pages (using a promise)
    #jpgStream()
rasterize.js: opening temp file
rasterize.js: closing temp file /var/folders/c7/qj7gqpcj06jbb1hkprks5ny80000gn/T/scissors117415-10822-cq8m6v.xt61kh85mi
rasterize.js: closed.
rasterize.js: [ 69, 30, 527, 769 ]
rasterize.js: ended
rasterize.js: Finished writing image.
      ✓ should extract a single jpg page (using default rasterize) (5965ms)
    #pngStream()
rasterize.js: opening temp file
rasterize.js: closing temp file /var/folders/c7/qj7gqpcj06jbb1hkprks5ny80000gn/T/scissors117415-10827-yyne5m.4o2loc4n29
rasterize.js: closed.
rasterize.js: [ 69, 30, 527, 769 ]
rasterize.js: ended
rasterize.js: Finished writing image.
      ✓ should extract a single png page (using default rasterize) (6073ms)
    #jpgStream()
simple_rasterize.js: Finished writing image.
      ✓ should extract a single jpg page (using simple rasterize) (622ms)
    #pngStream()
simple_rasterize.js: Finished writing image.
      ✓ should extract a single png page (using simple rasterize) (891ms)
    #jpgStream()
simple_rasterize.js: Finished writing image.
      ✓ should extract a single jpg page using crop box (using simple rasterize) (619ms)
    #pngStream()
simple_rasterize.js: Finished writing image.
      ✓ should extract a single png page using crop box (using simple rasterize) (876ms)
```

Output:

Original Rasterizer:
![_page1_default](https://cloud.githubusercontent.com/assets/48643/26071941/b7d5ff74-395e-11e7-8979-2ae8d86fc9cb.jpg)
![_page1_default](https://cloud.githubusercontent.com/assets/48643/26071942/b7d62ce2-395e-11e7-98c7-0c56ac2432f4.png)

New simple rasterizer with crop box
![_page1_simple_crop_box](https://cloud.githubusercontent.com/assets/48643/26071943/b7d7bb52-395e-11e7-9079-541f70e7a643.jpg)
![_page1_simple_crop_box](https://cloud.githubusercontent.com/assets/48643/26071944/b7d882d0-395e-11e7-818b-aa1ee99d34c4.png)

New simple rasterizer without crop box
![_page1_simple](https://cloud.githubusercontent.com/assets/48643/26071940/b7d5b0e6-395e-11e7-8460-3c722537576c.jpg)
![_page1_simple](https://cloud.githubusercontent.com/assets/48643/26071945/b7db4b8c-395e-11e7-91ae-d71fa9f5f7a6.png)
