### PR TITLE
use end keyword if no max is specified in range function

### DIFF
--- a/scissors.js
+++ b/scissors.js
@@ -139,7 +139,7 @@ Command.prototype.range = function (min, max) {
   var cmd = this._copy();
   return cmd._push([
     'pdftk', cmd._input(),
-    'cat', min + (max ? '-' + max : ''),
+    'cat', min + (max ? '-' + max : '-end'),
     'output', '-'
     ]);
 };


### PR DESCRIPTION
Hi, 

I just tried to use the `range` function without specifying the max parameter and it returned only one page. I solved the problem using the `end` keyword according to the documentation of pdftk.

Bye,
Fabrice.