### PR TITLE
feat: allow cleanup of temp files

### DIFF
--- a/bin/crop.js
+++ b/bin/crop.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs');
 var spawn = require('child_process').spawn;
+var rimraf = require('rimraf').sync;
 
 var temp = require('temp');
 require('bufferjs/indexOf');
@@ -100,10 +101,17 @@ temp.open('stripCropbox', function (err, info) {
 		debug('Scissors: closed.');
 		stripCropbox(process.stdin, fs.createWriteStream(info.path), function (err, cropbox) {
 			if (err) {
+				rimraf(info.path);
 				throw new Error(err);
 			}
+			var stream = fs.createReadStream(info.path);
+			stream.on('close', function () {
+				rimraf(info.path);
+			}).on('error', function () {
+				rimraf(info.path);
+			});
 			//fs.createReadStream(info.path).pipe(process.stdout);
-			writeCropbox(fs.createReadStream(info.path), combineCropboxes(cropbox, modcropbox))
+			writeCropbox(stream, combineCropboxes(cropbox, modcropbox))
 				.pipe(process.stdout);
 		});
 		process.stdin.resume();

--- a/bin/rasterize.js
+++ b/bin/rasterize.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs');
 var spawn = require('child_process').spawn;
+var rimraf = require('rimraf').sync;
 
 var temp = require('temp');
 require('bufferjs/indexOf');
@@ -99,9 +100,16 @@ createTempFile(function (path) {
 	var inputStream = input == '-' ? process.stdin : fs.createReadStream(input);
 	readBoundingBox(inputStream, page, function (err, boundingbox) {
 		if (err) {
+			rimraf(path);
 			return console.error(err);
 		}
-		rasterizeImage(fs.createReadStream(path), page, dpi, format, boundingbox)
+		var stream = fs.createReadStream(path);
+		stream.on('close', function () {
+			rimraf(path);
+		}).on('error', function () {
+			rimraf(path);
+		});
+		rasterizeImage(stream, page, dpi, format, boundingbox)
 			.pipe(process.stdout);
 	});
 	inputStream.resume();

--- a/package-lock.json
+++ b/package-lock.json
@@ -385,6 +385,15 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.1"
+      }
+    },
     "stream-to-promise": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-to-promise/-/stream-to-promise-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "async": "^2.4.0",
     "bufferjs": "^3.0.1",
     "bufferstream": "^0.6.2",
-    "temp": "^0.8.1"
+    "temp": "^0.8.1",
+    "rimraf": "^2.6.2"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
Allow user applications to cleanup generated temporary folders and files.
This is useful for applications that run for a long time, as the `temp` library will only cleanup at process exit.